### PR TITLE
Made a fix to a problem where Modernizr is not set when the tests excute

### DIFF
--- a/poly-compatibility.html
+++ b/poly-compatibility.html
@@ -48,7 +48,7 @@
                 this.showModal = true;                              
             },
             attached: function () {
-              _.bind(this._runTests,this);
+              this.async(this._runTests, 1000);
             },
             _runTests: function()
             {

--- a/poly-compatibility.html
+++ b/poly-compatibility.html
@@ -47,11 +47,8 @@
             {
                 this.showModal = true;                              
             },
-            ready: function () {
-                setTimeout(_.bind(this._runTests,this),1000);
-            },
             attached: function () {
-              
+              _.bind(this._runTests,this);
             },
             _runTests: function()
             {


### PR DESCRIPTION
I experienced the following error:

poly-compatibility.html:55 Uncaught ReferenceError: Modernizr is not defined
Polymer._runTests @ poly-compatibility.html:55

It started happening more frequently so I just moved the execution of the tests to the attached method and also changing the timeout to the Polymer async method.

Thanks for this component, it is pretty awesome!
